### PR TITLE
refactor: define discord bot client using subclasses

### DIFF
--- a/quote_bot/database.py
+++ b/quote_bot/database.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import DeclarativeBase
 
 load_dotenv()
 
@@ -33,4 +33,6 @@ engine = create_engine(
 )
 engine.connect()
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    pass

--- a/quote_bot/discord_components/app_commands/add_quote.py
+++ b/quote_bot/discord_components/app_commands/add_quote.py
@@ -1,0 +1,22 @@
+import discord
+from discord import app_commands
+
+
+class QuoteModal(discord.ui.Modal, title="Add Quote"):
+    text = discord.ui.TextInput(
+        label="Quote", style=discord.TextStyle.paragraph, required=True
+    )
+    speaker = discord.ui.TextInput(label="Speaker", required=True)
+    context = discord.ui.TextInput(label="Context", required=False)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.send_message(
+            f'✅ Quote stored:\n"{self.text}" — {self.speaker}'
+            + (f" ({self.context})" if self.context.value else ""),
+            ephemeral=True,
+        )
+
+
+@app_commands.command(name="add_quote", description="Add a quote via form")
+async def add_quote(interaction: discord.Interaction):
+    await interaction.response.send_modal(QuoteModal())


### PR DESCRIPTION
- Migrates the old definition of a discord bot (`client = commands.Bot(...)`) to the new definition where you subclass the `discord.Client` class. 
  - Followed the recommendation from [here](https://www.pythondiscord.com/pages/guides/python-guides/app-commands/)