### PR TITLE
feat: add a set_board command

### DIFF
--- a/quote_bot/discord_components/app_commands/set_board.py
+++ b/quote_bot/discord_components/app_commands/set_board.py
@@ -1,0 +1,9 @@
+import discord
+from discord import app_commands
+
+@app_commands.command(name="set_board", description="Set the current text channel as the quote board")
+async def set_board(interaction: discord.Interaction) -> None:
+  
+  with Session(engine) as session:
+    session.commit()
+    pass

--- a/quote_bot/discord_components/app_commands/set_board.py
+++ b/quote_bot/discord_components/app_commands/set_board.py
@@ -1,9 +1,15 @@
 import discord
 from discord import app_commands
+from sqlalchemy.orm import Session
 
-@app_commands.command(name="set_board", description="Set the current text channel as the quote board")
+from quote_bot.database import engine
+
+
+@app_commands.command(
+    name="set_board", description="Set the current text channel as the quote board"
+)
 async def set_board(interaction: discord.Interaction) -> None:
-  
-  with Session(engine) as session:
-    session.commit()
-    pass
+
+    with Session(engine) as session:
+        session.commit()
+        pass

--- a/quote_bot/discord_components/app_commands/set_board.py
+++ b/quote_bot/discord_components/app_commands/set_board.py
@@ -3,6 +3,7 @@ from discord import app_commands
 from sqlalchemy.orm import Session
 
 from quote_bot.database import engine
+from quote_bot.models.guild import Guild
 
 
 @app_commands.command(
@@ -10,6 +11,25 @@ from quote_bot.database import engine
 )
 async def set_board(interaction: discord.Interaction) -> None:
 
+    guild_id = interaction.guild.id if interaction.guild else None
+    channel_id = interaction.channel.id if interaction.channel else None
+
+    if not guild_id or not channel_id:
+        await interaction.response.send_message(
+            "Could not determine guild or channel.", ephemeral=True
+        )
+        return
+
     with Session(engine) as session:
+        guild = session.query(Guild).filter_by(id=guild_id).first()
+        if guild:
+            guild.quote_board_channel_id = channel_id
+        else:
+            guild = Guild(id=guild_id, quote_board_channel_id=channel_id)
+            session.add(guild)
         session.commit()
-        pass
+
+    await interaction.response.send_message(
+        f"✅ Set <#{channel_id}> as the quote board channel for this server.",
+        ephemeral=True,
+    )

--- a/quote_bot/discord_components/client.py
+++ b/quote_bot/discord_components/client.py
@@ -4,6 +4,7 @@ import discord
 from dotenv import load_dotenv
 
 from quote_bot.discord_components.app_commands.add_quote import add_quote
+from quote_bot.discord_components.app_commands.set_board import set_board
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -21,6 +22,7 @@ class QuoteBoardClient(discord.Client):
 
         # Register all the commands on startup
         self.tree.add_command(add_quote)
+        self.tree.add_command(set_board)
 
         print("All registered commands:")
         print("\t", list(map(lambda command: command.name, self.tree.get_commands())))

--- a/quote_bot/main.py
+++ b/quote_bot/main.py
@@ -10,7 +10,8 @@ from quote_bot.discord_components.client import client
 load_dotenv()
 
 # Initialize the database tables
-Base.metadata.create_all(engine)
+# Base.metadata.drop_all(bind=engine) # reset all tables
+Base.metadata.create_all(bind=engine)
 
 GUILD_ID = os.getenv("TESTING_GUILD_ID")
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")

--- a/quote_bot/models/exchange.py
+++ b/quote_bot/models/exchange.py
@@ -1,10 +1,25 @@
-from sqlalchemy import Column, Integer, String
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from quote_bot.database import Base
 
+# only for type hints
+if TYPE_CHECKING:
+    from quote_bot.models.statement import Statement
+
 
 class Exchange(Base):
-    __tablename__ = "exchanges"
+    """An exchange is a collection of statements and data associated with the group"""
 
-    id = Column(Integer, primary_key=True)  # arbitrary PK
-    context = Column(String, nullable=True)  # nullable string
+    __tablename__ = "exchange"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    """Unique ID of the exchange"""
+
+    context: Mapped[Optional[str]]
+    """The context or topic of the exchange"""
+
+    statements: Mapped[List["Statement"]] = relationship(
+        back_populates="exchange", cascade="all, delete-orphan"
+    )

--- a/quote_bot/models/guild.py
+++ b/quote_bot/models/guild.py
@@ -1,4 +1,10 @@
-from sqlalchemy import Column, Integer, String
+from typing import Optional
+
+
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import BigInteger
+
 
 from quote_bot.database import Base
 
@@ -8,8 +14,8 @@ class Guild(Base):
 
     __tablename__ = "guild"
 
-    id = Column(Integer, primary_key=True)
-    """Guild ID"""
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    """Guild IDs are 64 bit integers, so we use BigInteger here"""
 
-    quote_board_channel = Column(String)
-    """The channel ID of the quote board channel"""
+    quote_board_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    """Channel IDs are also 64 bit integers. This is the channel where quotes will be posted."""

--- a/quote_bot/models/guild.py
+++ b/quote_bot/models/guild.py
@@ -6,7 +6,7 @@ from quote_bot.database import Base
 class Guild(Base):
     """Stores all information specific to an individual Guild"""
 
-    __tablename__ = "guilds"
+    __tablename__ = "guild"
 
     id = Column(Integer, primary_key=True)
     """Guild ID"""

--- a/quote_bot/models/guild.py
+++ b/quote_bot/models/guild.py
@@ -1,10 +1,7 @@
 from typing import Optional
 
-
-from sqlalchemy.orm import Mapped
-from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy import BigInteger
-
+from sqlalchemy.orm import Mapped, mapped_column
 
 from quote_bot.database import Base
 
@@ -15,7 +12,9 @@ class Guild(Base):
     __tablename__ = "guild"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-    """Guild IDs are 64 bit integers, so we use BigInteger here"""
+    """Guild IDs are 64 bit ints, so we use BigInteger here"""
 
-    quote_board_channel_id: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
-    """Channel IDs are also 64 bit integers. This is the channel where quotes will be posted."""
+    quote_board_channel_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, nullable=True
+    )
+    """Channel IDs are 64 bit ints. This is the channel where quotes will be posted."""

--- a/quote_bot/models/statement.py
+++ b/quote_bot/models/statement.py
@@ -1,13 +1,26 @@
-from sqlalchemy import Column, ForeignKey, Integer, String
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from quote_bot.database import Base
 
+# only for type hints
+if TYPE_CHECKING:
+    from quote_bot.models.exchange import Exchange
+
 
 class Statement(Base):
-    __tablename__ = "statements"
+    """An individiual statement said by a single person"""
 
-    id = Column(Integer, primary_key=True)
-    speaker = Column(String, nullable=False)
-    statement = Column(String, nullable=False)
-    line_number = Column(Integer, nullable=False)
-    exchange_id = Column(Integer, ForeignKey("exchanges.id"), nullable=False)
+    __tablename__ = "statement"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    """Unique ID of the Statement"""
+
+    speaker: Mapped[str]
+    statement: Mapped[str]
+    line_number: Mapped[int]
+
+    exchange_id: Mapped[int] = mapped_column(ForeignKey("exchange.id"), nullable=False)
+    exchange: Mapped["Exchange"] = relationship(back_populates="statements")


### PR DESCRIPTION
- Adds the "/set_board" command, which defines the current board as the one to post all the quotes into.
- Adjusts the definitions of the `guild` table to store the 64 bit IDs as BigIntegers